### PR TITLE
Use correct class name for GET request labels

### DIFF
--- a/source/includes/_subscriptions.md
+++ b/source/includes/_subscriptions.md
@@ -3876,7 +3876,7 @@ This API returns all available subscription statuses.
 
 <div class="api-endpoint">
   <div class="endpoint-data">
-    <i class="label label-delete">GET</i>
+    <i class="label label-get">GET</i>
     <h6>/wp-json/wc/v3/subscriptions/statuses</h6>
   </div>
 </div>


### PR DESCRIPTION
The [GET label for the **Get statuses** section](https://woocommerce.github.io/subscriptions-rest-api-docs/?php#get-statuses) is currently incorrectly classed. It has the `label-delete` and so is incorrectly shown as red. See screenshot below. 

| Live | This change |
|--------|--------|
| <img width="419" alt="Screenshot 2024-07-01 at 5 38 52 PM" src="https://github.com/woocommerce/subscriptions-rest-api-docs/assets/8490476/8d1095ed-3070-440f-b60d-abce7632e880"> | <img width="412" alt="Screenshot 2024-07-01 at 5 40 38 PM" src="https://github.com/woocommerce/subscriptions-rest-api-docs/assets/8490476/62f715d7-bb5e-48fc-81d6-ce999d0df9a3"> | 



