### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       run: ./build.sh
     - name: Deploy to GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Closes [QAO-35](https://linear.app/a8c/issue/QAO-35/pin-github-actions-to-full-commit-shas)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
No version updates - used the latest commit in the tag that was already used.
